### PR TITLE
Audit Finding Cleanup

### DIFF
--- a/programs/minter-controller/src/instructions/accept_admin_transfer.rs
+++ b/programs/minter-controller/src/instructions/accept_admin_transfer.rs
@@ -23,6 +23,8 @@ pub struct AcceptAdminTransfer<'info> {
 
     #[account(
         mut,
+        has_one = minter_authority,
+        has_one = mint_account,
         constraint = minter.pending_admin == Some(pending_admin.key()),
         seeds = [b"minter", minter_authority.key().as_ref(), mint_account.key().as_ref()], 
         bump = minter.bump

--- a/programs/minter-controller/src/instructions/get_remaining_amount.rs
+++ b/programs/minter-controller/src/instructions/get_remaining_amount.rs
@@ -19,6 +19,8 @@ pub struct GetRemainingAmount<'info> {
 
     #[account(
         mut,
+        has_one = minter_authority,
+        has_one = mint_account,
         seeds = [b"minter", minter_authority.key().as_ref(), mint_account.key().as_ref()],
         bump = minter.bump,
     )]

--- a/programs/minter-controller/src/instructions/mint_token.rs
+++ b/programs/minter-controller/src/instructions/mint_token.rs
@@ -26,6 +26,8 @@ pub struct MintToken<'info> {
 
     #[account(
         mut,
+        has_one = minter_authority,
+        has_one = mint_account,
         seeds = [b"minter", minter_authority.key().as_ref(), mint_account.key().as_ref()],
         bump = minter.bump,
     )]

--- a/tests/minter_controller.ts
+++ b/tests/minter_controller.ts
@@ -1054,26 +1054,6 @@ describe('minter_controller', () => {
       expect(minterPda.pendingAdmin.toString()).to.equal(minterAuthorityKeypair.publicKey.toString())
     });
 
-    it('Cannot start admin transfer with None pending admin', async () => {
-      try {
-      await minterControllerProgram.methods
-        .startAdminTransfer(null)
-        .accounts({
-          minter: minterPDA,
-          payer: provider.wallet.publicKey,
-          minterAuthority: minterAuthorityKeypair.publicKey,
-          mintAccount: mintPDA,
-          admin: adminKeypair.publicKey
-        })
-        .signers([adminKeypair])
-        .rpc()
-        assert.fail('Expected err')
-      } catch (err) {
-        assert.isTrue(err.toString().includes('Cannot read properties of null'))
-      }
-  
-    });
-
     it('Cannot start admin transfer with missing admin signature', async () => {
       try {
         await minterControllerProgram.methods


### PR DESCRIPTION
This PR addresses a couple of audit finding follow ups:

- Adds missing has_one constraints
- Remove unit test doesn't test any error generated by the Paxos contract (it's throwing a JavaScript error). This can be safely removed as an empty pending_admin can't be accepted.