### PR TITLE
Update mint token instruction

### DIFF
--- a/programs/minter-controller/src/instructions/get_remaining_amount.rs
+++ b/programs/minter-controller/src/instructions/get_remaining_amount.rs
@@ -6,9 +6,6 @@ use crate::*;
 
 #[derive(Accounts)]
 pub struct GetRemainingAmount<'info> {
-    #[account()]
-    pub payer: Signer<'info>,
-
     /// CHECK: Minter authority 
     #[account()]
     pub minter_authority: UncheckedAccount<'info>,

--- a/programs/minter-controller/src/instructions/get_remaining_amount.rs
+++ b/programs/minter-controller/src/instructions/get_remaining_amount.rs
@@ -6,6 +6,9 @@ use crate::*;
 
 #[derive(Accounts)]
 pub struct GetRemainingAmount<'info> {
+    #[account()]
+    pub payer: Signer<'info>,
+
     /// CHECK: Minter authority 
     #[account()]
     pub minter_authority: UncheckedAccount<'info>,

--- a/programs/minter-controller/src/lib.rs
+++ b/programs/minter-controller/src/lib.rs
@@ -29,8 +29,8 @@ pub mod minter_controller {
         get_remaining_amount::get_remaining_amount(ctx, timestamp)
     }
 
-    pub fn mint_token(ctx: Context<MintToken>, amount: u64) -> Result<()> {
-        mint_token::mint_token(ctx, amount)
+    pub fn mint_token(ctx: Context<MintToken>, amount: u64, decimals: u8) -> Result<()> {
+        mint_token::mint_token(ctx, amount, decimals)
     }
 
     pub fn remove_whitelisted_address(ctx: Context<RemoveWhitelistedAddress>) -> Result<()> {

--- a/tests/minter_controller.ts
+++ b/tests/minter_controller.ts
@@ -56,7 +56,7 @@ describe('minter_controller', () => {
   const capacity = new anchor.BN(100);
   const amount = new anchor.BN(30);
   const refillPerSecond = new anchor.BN(20)
-  const data2 = new anchor.BN(45)
+  const decimals = 6;
 
   let mintMultisigAddr: PublicKey;
   let mintMultisigAddr2: PublicKey;
@@ -97,7 +97,7 @@ describe('minter_controller', () => {
       minterAuthorityKeypair, //Payer
       adminKeypair.publicKey, //Mint authority
       adminKeypair.publicKey, //Freeze authority
-      9,
+      decimals,
       undefined,
       undefined,
       TOKEN_2022_PROGRAM_ID
@@ -108,7 +108,7 @@ describe('minter_controller', () => {
       minterAuthorityKeypair, //Payer
       adminKeypair.publicKey, //Mint authority
       adminKeypair.publicKey, //Freeze authority
-      9,
+      decimals,
       undefined,
       undefined,
       TOKEN_2022_PROGRAM_ID
@@ -532,7 +532,7 @@ describe('minter_controller', () => {
   
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -558,7 +558,7 @@ describe('minter_controller', () => {
       }
   
       let tokenAmount = await provider.connection.getTokenAccountBalance(associatedTokenAccountAddress);
-      assert.equal(amount.toString(), tokenAmount.value.uiAmountString)
+      assert.equal(amount.toString(), tokenAmount.value.amount.toString())
       assert.isTrue(foundEvent)
     });
 
@@ -568,7 +568,7 @@ describe('minter_controller', () => {
   
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(capacity)
+        .mintToken(capacity, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -592,7 +592,7 @@ describe('minter_controller', () => {
   
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(capacity)
+        .mintToken(capacity, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -610,7 +610,7 @@ describe('minter_controller', () => {
       }
   
       let tokenAmount = await provider.connection.getTokenAccountBalance(associatedTokenAccountAddress);
-      assert.equal(amount.toString(), tokenAmount.value.uiAmountString)
+      assert.equal(amount.toString(), tokenAmount.value.amount.toString())
     });
 
     it('Cannot mint if rate limit exceeded over time period', async () => {
@@ -619,7 +619,7 @@ describe('minter_controller', () => {
   
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -637,7 +637,7 @@ describe('minter_controller', () => {
 
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(new anchor.BN(80)) //Remaining amount
+        .mintToken(new anchor.BN(80), decimals) //Remaining amount
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -659,7 +659,7 @@ describe('minter_controller', () => {
 
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(new anchor.BN(80))
+        .mintToken(new anchor.BN(80), decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -681,7 +681,7 @@ describe('minter_controller', () => {
       const associatedTokenAccountAddressToken2 = getAssociatedTokenAddressSync(mintPDAToken2, payer.publicKey, true, TOKEN_2022_PROGRAM_ID);
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -700,7 +700,7 @@ describe('minter_controller', () => {
       }
   
       let tokenAmount = await provider.connection.getTokenAccountBalance(associatedTokenAccountAddressToken2);
-      assert.equal(amount.toString(), tokenAmount.value.uiAmountString)
+      assert.equal(amount.toString(), tokenAmount.value.amount.toString())
     });
   
     it('Cannot mint tokens with non minter', async () => {
@@ -710,7 +710,7 @@ describe('minter_controller', () => {
   
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: badMinterAuthorityKeypair.publicKey,
           minterAuthority: badMinterAuthorityKeypair.publicKey,
@@ -732,7 +732,7 @@ describe('minter_controller', () => {
     it('Cannot mint tokens without minter authority signature', async () => {
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -756,7 +756,7 @@ describe('minter_controller', () => {
 
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -781,7 +781,7 @@ describe('minter_controller', () => {
 
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: badMinterAuthorityKeypair.publicKey,
           minterAuthority: badMinterAuthorityKeypair.publicKey,
@@ -804,7 +804,7 @@ describe('minter_controller', () => {
     it('Cannot mint tokens with mismatched minter authority signature for other minter authority', async () => {
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: provider.publicKey,
           minterAuthority: provider.publicKey,
@@ -827,7 +827,7 @@ describe('minter_controller', () => {
     it('Cannot mint tokens to another mint account', async () => {
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
@@ -851,7 +851,7 @@ describe('minter_controller', () => {
       const associatedTokenAccountAddress = getAssociatedTokenAddressSync(mintPDA, badMinterAuthorityKeypair.publicKey, true, TOKEN_2022_PROGRAM_ID);
       try {
         const mintTokenSignature = await minterControllerProgram.methods
-        .mintToken(amount)
+        .mintToken(amount, decimals)
         .accounts({
           payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,

--- a/tests/minter_controller.ts
+++ b/tests/minter_controller.ts
@@ -877,12 +877,10 @@ describe('minter_controller', () => {
         const tx = await minterControllerProgram.methods
         .getRemainingAmount(new anchor.BN(Date.now() + 86400)) //1 day since last tx
         .accounts({
-          payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
           mintAccount: mintPDA,
           minter: minterPDA,
         })
-        .signers([minterAuthorityKeypair])
         .rpc(confirmOptions);
 
         let t = await provider.connection.getTransaction(tx, {
@@ -908,12 +906,10 @@ describe('minter_controller', () => {
         const tx = await minterControllerProgram.methods
         .getRemainingAmount(new anchor.BN(last_refill_time + ELAPSED_SECONDS))
         .accounts({
-          payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
           mintAccount: mintPDA,
           minter: minterPDA,
         })
-        .signers([minterAuthorityKeypair])
         .rpc(confirmOptions);
 
         let t = await provider.connection.getTransaction(tx, {

--- a/tests/minter_controller.ts
+++ b/tests/minter_controller.ts
@@ -877,10 +877,12 @@ describe('minter_controller', () => {
         const tx = await minterControllerProgram.methods
         .getRemainingAmount(new anchor.BN(Date.now() + 86400)) //1 day since last tx
         .accounts({
+          payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
           mintAccount: mintPDA,
           minter: minterPDA,
         })
+        .signers([minterAuthorityKeypair])
         .rpc(confirmOptions);
 
         let t = await provider.connection.getTransaction(tx, {
@@ -906,10 +908,12 @@ describe('minter_controller', () => {
         const tx = await minterControllerProgram.methods
         .getRemainingAmount(new anchor.BN(last_refill_time + ELAPSED_SECONDS))
         .accounts({
+          payer: minterAuthorityKeypair.publicKey,
           minterAuthority: minterAuthorityKeypair.publicKey,
           mintAccount: mintPDA,
           minter: minterPDA,
         })
+        .signers([minterAuthorityKeypair])
         .rpc(confirmOptions);
 
         let t = await provider.connection.getTransaction(tx, {


### PR DESCRIPTION
1. Update mint_token instruction to call `mint_to_checked` instead of `mint_to`
2. Remove decimal correction
3. Update unit tests accordingly